### PR TITLE
Updating to install via github url

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.6.2 (C:\Python\python.exe) (1)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/skill-installer.iml" filepath="$PROJECT_DIR$/.idea/skill-installer.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/preferred-vcs.xml
+++ b/.idea/preferred-vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PreferredVcsStorage">
+    <preferredVcsName>ApexVCS</preferredVcsName>
+  </component>
+</project>

--- a/.idea/skill-installer.iml
+++ b/.idea/skill-installer.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="0a89595f-4e7f-49d6-9d33-f807b73abb05" name="Default" comment="" />
+    <option name="TRACKING_ENABLED" value="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ShelveChangesManager" show_recycled="false">
+    <option name="remove_strategy" value="false" />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <created>1507895539322</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1507895539322</updated>
+    </task>
+    <servers />
+  </component>
+  <component name="VcsContentAnnotationSettings">
+    <option name="myLimit" value="2678400000" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager />
+    <watches-manager />
+  </component>
+</project>

--- a/__init__.py
+++ b/__init__.py
@@ -87,7 +87,7 @@ class SkillInstallerSkill(MycroftSkill):
 
         # Invoke MSM to perform installation
         try:
-            cmd = ' '.join([BIN, 'install', '"' + url)
+            cmd = ' '.join([BIN, 'install' + url)
             output = subprocess.check_output(cmd, shell=True)
             self.log.info("MSM output: " + str(output))
             rc = 0

--- a/__init__.py
+++ b/__init__.py
@@ -87,7 +87,7 @@ class SkillInstallerSkill(MycroftSkill):
 
         # Invoke MSM to perform installation
         try:
-            cmd = ' '.join([BIN, 'install' + url)
+            cmd = ' '.join([BIN, 'install', + url])
             output = subprocess.check_output(cmd, shell=True)
             self.log.info("MSM output: " + str(output))
             rc = 0

--- a/__init__.py
+++ b/__init__.py
@@ -85,10 +85,11 @@ class SkillInstallerSkill(MycroftSkill):
         url = utterance.replace(message.data.get('Github'), '')
         self.log.debug("The url is: {}".format(url))
         self.speak_dialog("installing")
+        url = str(url)
 
         # Invoke MSM to perform installation
         try:
-            cmd = ' '.join([BIN, 'install', + url])
+            cmd = ' '.join([BIN, 'install', + '"' + url.strip() + '"'])
             output = subprocess.check_output(cmd, shell=True)
             self.log.info("MSM output: " + str(output))
             rc = 0

--- a/__init__.py
+++ b/__init__.py
@@ -80,7 +80,7 @@ class SkillInstallerSkill(MycroftSkill):
                                                           'error': rc})
 
     @intent_handler(IntentBuilder("GithubIntent").require("Github"))
-    def install(self, message):
+    def install_github(self, message):
         utterance = message.data.get('utterance').lower()
         url = message.data["url"]
         self.log.debug("The url is: {}".format(url))

--- a/__init__.py
+++ b/__init__.py
@@ -79,7 +79,7 @@ class SkillInstallerSkill(MycroftSkill):
             self.speak_dialog("installation.error", data={'skill': name,
                                                           'error': rc})
 
-    @intent_handler(IntentBuilder("GithubIntent").require("Github"))
+    @intent_handler(IntentBuilder("GithubIntent").require("Github").require("url"))
     def install_github(self, message):
         utterance = message.data.get('utterance').lower()
         url = message.data["url"]

--- a/__init__.py
+++ b/__init__.py
@@ -83,7 +83,7 @@ class SkillInstallerSkill(MycroftSkill):
     def install_github(self, message):
         utterance = message.data.get('utterance').lower()
         url = utterance.replace(message.data.get('Github'), '')
-        self.log.debug("The url is: {}".format(url))
+        self.log.debug("The url is: {}".format(url.strip(" ")))
         self.speak_dialog("installing")
 
         # Invoke MSM to perform installation

--- a/__init__.py
+++ b/__init__.py
@@ -85,7 +85,6 @@ class SkillInstallerSkill(MycroftSkill):
         url = utterance.replace(message.data.get('Github'), '')
         self.log.debug("The url is: {}".format(url))
         self.speak_dialog("installing")
-        url = str(url)
 
         # Invoke MSM to perform installation
         try:

--- a/__init__.py
+++ b/__init__.py
@@ -83,12 +83,12 @@ class SkillInstallerSkill(MycroftSkill):
     def install_github(self, message):
         utterance = message.data.get('utterance').lower()
         url = message.data["url"]
-        self.log.debug("The url is: {}".format(url))
+        self.log.debug("The url is: {}".format(str(url)))
         self.speak_dialog("installing")
 
         # Invoke MSM to perform installation
         try:
-            cmd = ' '.join([BIN, 'install', + url])
+            cmd = ' '.join([BIN, 'install', + str(url)])
             output = subprocess.check_output(cmd, shell=True)
             self.log.info("MSM output: " + str(output))
             rc = 0

--- a/__init__.py
+++ b/__init__.py
@@ -82,7 +82,7 @@ class SkillInstallerSkill(MycroftSkill):
     @intent_handler(IntentBuilder("GithubIntent").require("Github"))
     def install(self, message):
         utterance = message.data.get('utterance').lower()
-        url = message.data["URL"]
+        url = message.data["url"]
         self.speak_dialog("installing")
 
         # Invoke MSM to perform installation

--- a/__init__.py
+++ b/__init__.py
@@ -88,7 +88,7 @@ class SkillInstallerSkill(MycroftSkill):
 
         # Invoke MSM to perform installation
         try:
-            cmd = ' '.join([BIN, 'install', + url ])
+            cmd = ''.join([BIN, 'install', + url])
             output = subprocess.check_output(cmd, shell=True)
             self.log.info("MSM output: " + str(output))
             rc = 0

--- a/__init__.py
+++ b/__init__.py
@@ -79,6 +79,36 @@ class SkillInstallerSkill(MycroftSkill):
             self.speak_dialog("installation.error", data={'skill': name,
                                                           'error': rc})
 
+    @intent_handler(IntentBuilder("GithubIntent").require("Github"))
+    def install(self, message):
+        utterance = message.data.get('utterance').lower()
+        url = message.data["URL"]
+        self.speak_dialog("installing")
+
+        # Invoke MSM to perform installation
+        try:
+            cmd = ' '.join([BIN, 'install', '"' + url)
+            output = subprocess.check_output(cmd, shell=True)
+            self.log.info("MSM output: " + str(output))
+            rc = 0
+        except subprocess.CalledProcessError, e:
+            output = e.output
+            rc = e.returncode
+        if rc == 0:
+            # Success!
+            # TODO: Speak the skill name?  Parse for "Installed: (.*)"
+            self.speak_dialog("installed", data={'skill': url})
+        elif rc == 20:
+            # Already installed
+            self.speak_dialog("already.installed", data={'skill': url})
+        elif rc == 202:
+            # Not found
+            self.speak_dialog("not.found", data={'skill': url})
+        else:
+            # Other installation error, just read code
+            self.speak_dialog("installation.error", data={'skill': url,
+                                                          'error': rc})
+
     @intent_handler(IntentBuilder("UninstallIntent").require("Uninstall"))
     def uninstall(self, message):
         utterance = message.data.get('utterance').lower()

--- a/__init__.py
+++ b/__init__.py
@@ -83,6 +83,7 @@ class SkillInstallerSkill(MycroftSkill):
     def install(self, message):
         utterance = message.data.get('utterance').lower()
         url = message.data["url"]
+        self.log.debug("The url is: {}".format(url))
         self.speak_dialog("installing")
 
         # Invoke MSM to perform installation

--- a/__init__.py
+++ b/__init__.py
@@ -82,13 +82,13 @@ class SkillInstallerSkill(MycroftSkill):
     @intent_handler(IntentBuilder("GithubIntent").require("Github").require("url"))
     def install_github(self, message):
         utterance = message.data.get('utterance').lower()
-        url = message.data["url"]
-        self.log.debug("The url is: {}".format(str(url)))
+        url = utterance.replace(message.data.get('Github'), '')
+        self.log.debug("The url is: {}".format(url))
         self.speak_dialog("installing")
 
         # Invoke MSM to perform installation
         try:
-            cmd = ' '.join([BIN, 'install', + str(url)])
+            cmd = ' '.join([BIN, 'install', + url])
             output = subprocess.check_output(cmd, shell=True)
             self.log.info("MSM output: " + str(output))
             rc = 0

--- a/__init__.py
+++ b/__init__.py
@@ -88,7 +88,7 @@ class SkillInstallerSkill(MycroftSkill):
 
         # Invoke MSM to perform installation
         try:
-            cmd = ''.join([BIN, 'install', + url])
+            cmd = ''.join([BIN, 'install' + url])
             output = subprocess.check_output(cmd, shell=True)
             self.log.info("MSM output: " + str(output))
             rc = 0

--- a/__init__.py
+++ b/__init__.py
@@ -88,7 +88,7 @@ class SkillInstallerSkill(MycroftSkill):
 
         # Invoke MSM to perform installation
         try:
-            cmd = ''.join([BIN, 'install' + url])
+            cmd = ' '.join([BIN, 'install' + url])
             output = subprocess.check_output(cmd, shell=True)
             self.log.info("MSM output: " + str(output))
             rc = 0

--- a/__init__.py
+++ b/__init__.py
@@ -88,7 +88,7 @@ class SkillInstallerSkill(MycroftSkill):
 
         # Invoke MSM to perform installation
         try:
-            cmd = ' '.join([BIN, 'install', + '"' + url.strip() + '"'])
+            cmd = ' '.join([BIN, 'install', + url ])
             output = subprocess.check_output(cmd, shell=True)
             self.log.info("MSM output: " + str(output))
             rc = 0

--- a/regex/en-us/url.rx
+++ b/regex/en-us/url.rx
@@ -1,1 +1,1 @@
-install github url (?P<URL>.*)
+install github url (?P<url>.*)

--- a/regex/en-us/url.rx
+++ b/regex/en-us/url.rx
@@ -1,0 +1,1 @@
+install github url (?P<URL>.*)

--- a/vocab/en-us/Github.voc
+++ b/vocab/en-us/Github.voc
@@ -1,0 +1,1 @@
+install github url


### PR DESCRIPTION
For the web client I'm building to enable skill writers and reviewers to test skills before adding them to the repo I wanted the install skill to allow for this.

So you can now do `install github url https://github.com/tjoen/mycroft-skill-numbers.git` to install a skill, below is a screenshot from the UI I'm building showing it working

![image](https://user-images.githubusercontent.com/1426587/31547305-d1023618-aff4-11e7-8fdf-73969c2315bc.png)
