### PR TITLE
Fixed the parsing of msm output

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -40,11 +40,11 @@ class SkillInstallerSkill(MycroftSkill):
         try:
             cmd = ' '.join([BIN, 'install', '"' + name.strip() + '"'])
             output = subprocess.check_output(cmd, shell=True)
-            self.log.info("MSM output: " + str(output))
             rc = 0
         except subprocess.CalledProcessError, e:
             output = e.output
             rc = e.returncode
+        self.log.info("MSM output: " + str(output))
 
         if rc == 0:
             # Success!
@@ -63,6 +63,11 @@ class SkillInstallerSkill(MycroftSkill):
                 skills = match.group(1)
             else:
                 skills = ""
+
+            # split by lines
+            skills = skills.split("\n")
+            # remove empty lines
+            skills = list(filter(lambda x: len(x) > 0, skills))
 
             # read the list for followup
             self.speak_dialog("choose", data={'skills': ", ".join(skills)})


### PR DESCRIPTION
The msm output was not split before, so the joined string (for matches abc and abcd) would read like "There were multiple packages found: a,b,c,a,b,c,d". This is now fixed.

Also the output of msm would only be logged if there was no error which is kind of unintuitive. Maybe rather no log at all.