### PR TITLE
Handle msm failing to fetch skill list

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -171,7 +171,13 @@ class SkillInstallerSkill(MycroftSkill):
             action = 'installing'
         utterance = message.data['utterance'].lower()
         search = utterance.replace(message.data['Install'], '').strip()
-        skills = self.search_for_skill(search, self.get_skill_list())
+        try:
+            skills = self.search_for_skill(search, self.get_skill_list())
+        except subprocess.CalledProcessError as e:
+            self.log.error(
+                "MSM returned " + str(e.returncode) + ": " + e.output)
+            self.speak_dialog("skill.list.failed")
+            return
 
         if not skills:
             self.speak_dialog("not.found", dict(skill=search, action=action))

--- a/dialog/en-us/skill.list.failed.dialog
+++ b/dialog/en-us/skill.list.failed.dialog
@@ -1,0 +1,1 @@
+I could not fetch the skill list, please try again in a while


### PR DESCRIPTION
Handle msm error 111 and 112 more gracefully telling the user that fetching of the skill list failed. 