### PR TITLE
Auto-install fix, minor changes for 18.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # <img src='https://rawgithub.com/FortAwesome/Font-Awesome/master/advanced-options/raw-svg/solid/download.svg' card_color='#22a7f0' width='50' height='50' style='vertical-align:bottom'/> Installer
-Install Mycroft Skills using voice commands
+Add and remove Mycroft Skills
 
-## About 
-Add and remove Skills using `msm` - the [Mycroft Skill Manager](https://mycroft.ai/documentation/msm].  Install a
-Skill verbally by saying `Install SKILL-IDENTIFIER`, where `SKILL-IDENTIFIER` is the full name or at least adequate subset of the name to uniquely identify the Skill.  
+## About
+Add and remove Skills using your voice or from the [Marketplace](https://market.mycroft.ai).
+You can also assist skill authors in testing new versions of their skills by
+using "install prevew version" to gain access to skills still under development
+and testing.  If you do this, please be consicious the skill may be in an
+unstable development state and report issues to the author appropriately.
 
-[See the full list of available Mycroft Skills.](https://mycroft.ai/skills)
+You can also install Skills that are not officially released by entering the
+Skill's GitHub repository URL in the [Installer's web user interface](https://home.mycroft.ai/#/skill).
 
-You can also install Skills that are not in the `mycroft-skills` official repo by entering the Skill's GitHub repo
-URL in the [Installer web user interface](https://home.mycroft.ai/#/skill).
+Skills are ultimately installed using the [Mycroft Skill Manager (msm)](https://mycroft.ai/documentation/msm].  If verbally installing, Mycroft will speak a list of possible matches for
+ambiguous names -- just pick the skill you want from the list read to you.
 
-## Examples 
+## Examples
 * "Install coin flip"
+* "Install the preview version of coin flip "
 * "Uninstall coin flip"
 * "Remove coin flip"
 * "Download custom skill"
 
-## Credits 
+## Credits
 Mycroft AI (@MycroftAI)
 
 ## Category
@@ -30,3 +35,4 @@ Mycroft AI (@MycroftAI)
 #skill
 #skills
 #msm
+#system

--- a/dialog/en-us/cancelled.dialog
+++ b/dialog/en-us/cancelled.dialog
@@ -1,3 +1,2 @@
-Okay.
-Alright.
-Understood.
+Cancelled.
+Action cancelled.

--- a/dialog/en-us/choose.skill.dialog
+++ b/dialog/en-us/choose.skill.dialog
@@ -1,1 +1,1 @@
-Multiple skills found, which would you like me to choose: {{skills}}
+Multiple skills found, which would you like... {{skills}}

--- a/dialog/en-us/error.already.beta.dialog
+++ b/dialog/en-us/error.already.beta.dialog
@@ -1,1 +1,1 @@
-{{skill}} has already been installed as beta.
+The preview version of {{skill}} has already been installed.

--- a/dialog/en-us/error.already.removed.dialog
+++ b/dialog/en-us/error.already.removed.dialog
@@ -1,1 +1,2 @@
-{{skill}} has already been removed
+{{skill}} is not installed
+{{skill}} was not found on this device

--- a/dialog/en-us/error.not.found.dialog
+++ b/dialog/en-us/error.not.found.dialog
@@ -1,1 +1,1 @@
-I didn't find any skill name {{skill}}.
+I didn't find any skill named {{skill}}.

--- a/dialog/en-us/error.pip.requirements.dialog
+++ b/dialog/en-us/error.pip.requirements.dialog
@@ -1,1 +1,1 @@
-An error occurred while {{action}} the python dependencies for {{skill}}.
+An error occurred while {{action}} the Python dependencies for {{skill}}.

--- a/dialog/en-us/error.too.many.skills.dialog
+++ b/dialog/en-us/error.too.many.skills.dialog
@@ -1,1 +1,1 @@
-Your request had multiple matches, please be more specific. There were too many matches to read them.
+Your request had multiple matches, please be more specific.

--- a/dialog/en-us/install.beta.complete.dialog
+++ b/dialog/en-us/install.beta.complete.dialog
@@ -1,1 +1,1 @@
-Beta {{skill}} is now installed and ready for use
+The development version of {{skill}} has been installed.  This version has not undergone any community review or quality control testing, so be responsible when reporting issues to the author.  To switch back to the officially released version, say: install {{skill}}.

--- a/dialog/en-us/install.beta.confirm.dialog
+++ b/dialog/en-us/install.beta.confirm.dialog
@@ -1,1 +1,1 @@
-Confirming: shall I install beta {{skill}} by {{author}}.
+Confirming: Shall I switch from the officially released version of {{skill}} to the development version?

--- a/dialog/en-us/install.beta.upgrade.confirm.dialog
+++ b/dialog/en-us/install.beta.upgrade.confirm.dialog
@@ -1,1 +1,1 @@
-Confirming: shall I upgrade {{skill}} to beta.
+Confirming: Shall I upgrade {{skill}} to the latest development version?

--- a/dialog/en-us/install.confirm.dialog
+++ b/dialog/en-us/install.confirm.dialog
@@ -1,1 +1,1 @@
-Confirming: shall I install {{skill}} by {{author}}.
+Confirming: Shall I install {{skill}} by {{author}}.

--- a/dialog/en-us/install.reinstall.confirm.dialog
+++ b/dialog/en-us/install.reinstall.confirm.dialog
@@ -1,1 +1,1 @@
-Confirming: shall I reinstall the stable version of {{skill}}?
+Confirming: Shall I reinstall the official release version of {{skill}}?

--- a/dialog/en-us/some.available.skills.dialog
+++ b/dialog/en-us/some.available.skills.dialog
@@ -1,1 +1,1 @@
-Here's a few skills you can install, {{skills}} 
+Here are a few of the skills you can install... {{skills}}

--- a/dialog/en-us/yes.list
+++ b/dialog/en-us/yes.list
@@ -1,5 +1,0 @@
-yes
-sure
-yup
-yeah
-yep

--- a/vocab/en-us/install.beta.intent
+++ b/vocab/en-us/install.beta.intent
@@ -1,3 +1,3 @@
 install {skill} (version|) beta.
-install (the|) beta (version|of|) {skill}.
-install (the|) version beta of {skill}.
+install {skill} (beta|preview) version
+install (the|) (beta|preview) (version|)(of|) {skill}.

--- a/vocab/en-us/install.intent
+++ b/vocab/en-us/install.intent
@@ -1,4 +1,4 @@
 install {skill}.
-install {skill} (version|) stable.
-install stable (version|of|) {skill}.
-install version stable of {skill}.
+install {skill} (version|) (stable|official).
+install (the|) (official|stable) (version|of|) {skill}.
+install official release (version|) of {skill}.

--- a/vocab/en-us/remove.intent
+++ b/vocab/en-us/remove.intent
@@ -1,2 +1,4 @@
 uninstall (skill|) {skill}
 remove skill {skill}
+uninstall {skill} (skill|)
+remove {skill} skill


### PR DESCRIPTION
This fixes several 18.08 issues:
* Using new MycroftSkill.ask_yesno() mechanism instead of custom "yes.list"
* Removed backwards compatibility try/catches to keep code clean
* Adopted Python 3 idioms, such as super()
* Migrate bool setting usage, dropping unnecessary string test ```s["auto_install"] == 'true'```

Plus some general usability:
* Clean up presentation of skill names.  E.g. "email" instead of "skill-email"
* Add layer to clean up github user name.  Currently hardcoded cleanup for "Mycroft AI", but will use Github info later.
* Cleaned up joined skill lists, separating with "." instead of "," to improve pauses in pronunciation.
* Cleaned up dialog verbage
* Added information for reverting to official release at the end of a beta install

README.md cleanup
* Description enhancements
* Added example of a preview install
* Added #system hashtag for the Marketplace