### PR TITLE
Removing unused 'yes.list'

### DIFF
--- a/dialog/de-de/yes.list
+++ b/dialog/de-de/yes.list
@@ -1,5 +1,0 @@
-ja
-sicher
-natürlich
-jop
-jawoll


### PR DESCRIPTION
The 'yes.list' was removed in favor of the system wide 'yes' defined for
MycroftSkills.ask_yesno()