### PR TITLE
true > "true"

### DIFF
--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -26,7 +26,7 @@
 		    {
 		        "name": "to_install",
 		        "type": "text",
-                        "hide": true,
+                        "hide": "true",
 		        "value": "[]"
 		    },
 		    {


### PR DESCRIPTION
Just noticed a rogue `true` value in the settingsmeta.json