### PR TITLE
Removed deprecated (name, color) values

### DIFF
--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,6 +1,4 @@
 {
-    "name": "Installer",
-    "color": "#22a7f0",
     "skillMetadata": {
         "sections": [
             {


### PR DESCRIPTION
Removed deprecated values from Skills settingsmeta.json (reported in issue #1092).