### PR TITLE
Security enhancement: remove automatic Skill installation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -214,25 +214,11 @@ class SkillInstallerSkill(MycroftSkill):
             self.speak_dialog('cancelled')
 
     def on_web_settings_change(self):
-        s = self.settings
-        link = s.get('installer_link')
-        prev_link = s.get('previous_link')
-        auto_install = s.get('auto_install')
 
-        # Check if we should auto-install a skill due to web setting change
-        if link and prev_link != link and auto_install:
-            s['previous_link'] = link
-
-            self.log.info('Installing from the web...')
-            action = self.translate_list('action')[0]
-            name = SkillEntry.extract_repo_name(link)
-            with self.handle_msm_errors(name, action):
-                self.msm.install(link)
-
-        to_install = s.get('to_install', [])
+        to_install = self.settings.get('to_install', [])
         if isinstance(to_install, str):
             to_install = json.loads(to_install)
-        to_remove = s.get('to_remove', [])
+        to_remove = self.settings.get('to_remove', [])
         if isinstance(to_remove, str):
             to_remove = json.loads(to_remove)
         self.handle_marketplace(to_install, to_remove)

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -15,12 +15,6 @@
                         "placeholder": "https://github.com/example/...",
                         "value": ""
                     },
-                    {
-                        "name": "auto_install",
-                        "type": "checkbox",
-                        "label": "Automatic Install",
-                        "value": "false"
-                    },
 		    {
 		        "name": "to_install",
 		        "type": "text",

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -6,7 +6,7 @@
                 "fields": [
                     {
                         "type": "label",
-                        "label": "<p>Registered <a href='https://github.com/MycroftAI/mycroft-skills'>skills</a> can easily be installed  with voice commands like \"install coin flip\".  Here you can enter a URL for a private skill or skill in development.<p/><p>Provide the URL to the Skill repository below.  When Automatic Install is checked, the installation will occur within a minute on all your devices. When not checked, you can intiate the installation by saying \"Download custom skill\".</p>"
+                        "label": "<p>Skills registered in the <a href='https://market.mycroft.ai/skills'>Marketplace</a> can be installed with voice commands like \"install speedtest\".  Here you can enter a URL for a private Skill or Skill in development.<p/><p>Provide the URL to the Skill repository below.  You can intiate the installation by saying \"Hey Mycroft, download custom skill\".</p>"
                     },
                     {
                         "name": "installer_link",

--- a/vocab/en-us/install.custom.intent
+++ b/vocab/en-us/install.custom.intent
@@ -1,1 +1,1 @@
-Download custom skill
+Download (my|the|) custom skill


### PR DESCRIPTION
Updating Skill settings to remove the `auto_install` option. 

This setting allowed a user to install a Skill from any repository remotely onto their device with no interaction on the hardware itself. Removing this now requires that the user enter the url in their Skill settings, then initiate the download by saying:
> Hey Mycroft, download my custom skill

The `to_install` and `to_remove` settings are still able to operate without local interaction as these must come from the Marketplace and have therefore been reviewed by the Skills Management Team. These two settings should also be documented more clearly.