### PR TITLE
remove setting fields not currently in use

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -223,6 +223,9 @@ class SkillInstallerSkill(MycroftSkill):
         """Callback on changed settings.
 
         Handles updating skill installation from Marketplace.
+        
+        NOTE: Not yet implemented on new Selene backend. 
+        These settings have been disabled until the functionality is restored.
         """
         to_install = self.settings.get('to_install', [])
         to_remove = self.settings.get('to_remove', [])

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -15,18 +15,18 @@
                         "placeholder": "https://github.com/example/...",
                         "value": ""
                     },
-		    {
-		        "name": "to_install",
-		        "type": "text",
+                    {
+                        "name": "to_install",
+                        "type": "disabled-text-field",
                         "hide": "true",
-		        "value": "[]"
-		    },
-		    {
-		        "name": "to_remove",
-		        "type": "text",
+                        "value": "[]"
+                    },
+                    {
+                        "name": "to_remove",
+                        "type": "disabled-text-field",
                         "hide": "true",
-		        "value": "[]"
-		    }
+                        "value": "[]"
+                    }
                 ]
             }
         ]


### PR DESCRIPTION
As these fields aren't been correctly hidden by the Selene UI, and they aren't operational anyway. I have deactivated the fields by assigning them an invalid type. Also included a note in the settings changed callback to avoid confusion if people are trying to use them.